### PR TITLE
chore: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 <p align="center"> English | <a href="./README_zh.md">简体中文</a></p>
 
-VS Code extension -> transform CSS to TailwindCSS
+VS Code extension → transform CSS to TailwindCSS
 
 ## Feature
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
 <img height="200" src="./assets/kv.png" alt="to tailwindcss">
 </p>
-<p align="center"> English | <a href="./README_zh.md">简体中文</a></p>
+<p align="center"> English | <a href="https://github.com/Simon-He95/to-tailwindcss/blob/main/README_zh.md">简体中文</a></p>
 
 VS Code extension → transform CSS to TailwindCSS
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 <p align="center">
 <img height="200" src="./assets/kv.png" alt="to tailwindcss">
 </p>
-<p align="center"> English | <a href="https://github.com/Simon-He95/to-tailwindcss/README_zh.md">简体中文</a></p>
+<p align="center"> English | <a href="./README_zh.md">简体中文</a></p>
 
-vscode extension -> transform css to tailwindcss
+VS Code extension -> transform CSS to TailwindCSS
 
 ## Feature
 
-- if your project not found `tailwind.config.ts` or `tailwind.config.js`, the extension will not be activated
+- if your project not found `tailwind.config.ts` or `tailwind.config.js`, the extension will not be activated.
 
-- Support css in the design draft directly through the shortcut key `Mac`? `cmd+alt+x` : `ctrl+alt+x` is automatically converted to tailwindcss, and will be automatically processed into in-line tailwindcss format or class form according to your location.
+- **How to support CSS in the design draft directly through the shortcut key `Mac`?** Use after copying `cmd+alt+x` / `ctrl+alt+x` is automatically converted to TailwindCSS, and will be automatically processed into in-line TailwindCSS format or class form according to your location.
 
 ## :coffee:
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,7 +1,7 @@
 <p align="center">
 <img height="200" src="./assets/kv.png" alt="to tailwindcss">
 </p>
-<p align="center"> <a href="./README.md">English</a> | 简体中文</p>
+<p align="center"> <a href="https://github.com/Simon-He95/to-tailwindcss/blob/main/README.md">English</a> | 简体中文</p>
 
 VS Code 扩展 → 将原生 CSS 样式转换为 TailwindCSS
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,15 +1,15 @@
 <p align="center">
 <img height="200" src="./assets/kv.png" alt="to tailwindcss">
 </p>
-<p align="center"> <a href="https://github.com/Simon-He95/to-tailwindcss/README.md">English</a> | 简体中文</p>
+<p align="center"> <a href="./README.md">English</a> | 简体中文</p>
 
-vscode扩展 -> 将css转换为tailwindcss
+VS Code 扩展 → 将原生 CSS 样式转换为 TailwindCSS
 
 ## Feature
 
--如果您的项目没有找到`tailwind.config.ts`或`tailwind.config.js`，该扩展将不会被激活
+- 如果您的项目没有找到 `tailwind.config.ts` 或 `tailwind.config.js`，该扩展将不会被激活。
 
--直接通过快捷键“Mac”支持设计草案中的css？`cmd+alt+x`：`ctrl+alt+x`会自动转换为tailwindcss，并将根据您的位置自动处理为在线尾风css格式或类形式。
+- **如何通过快捷键“Mac”支持设计草案中的 CSS？** 复制后使用快捷键 `cmd+alt+x` / `ctrl+alt+x` 会自动将 CSS 样式转换为 TailwindCSS，并将根据您的位置自动处理为内嵌 CSS 格式或类形式。
 
 ## :coffee:
 


### PR DESCRIPTION
发现 README 中提供的中文和英文链接，都无法完成正确的跳转，如下图所示

<img width="1195" alt="image" src="https://github.com/Simon-He95/to-tailwindcss/assets/48991003/e62c0aac-5361-4917-a4fb-2ce542e89cfe">

所以就更新了下，顺便也更改了些名词，如：css → CSS，tailwindcss → TailwindCSS 等等，添加了中文与英文之间的空格，观感来说更美观

> 其实在仓库地址后加上 `bold/main/` 的话也可以，比如

- `https://github.com/Simon-He95/to-tailwindcss/blob/main/README.md`
- `https://github.com/Simon-He95/to-tailwindcss/blob/main/README_zh.md`

但看了下 Simon 哥其他项目 README 貌似用的都是相对路径，那就统一用 `./` 了 😊